### PR TITLE
Upgrade to alpine:3.13.1 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11.6
+FROM alpine:3.13.1
 
 LABEL maintainer="Mark <mark.binlab@gmail.com>"
 


### PR DESCRIPTION
Build on top of the current `alpine` base image.

Because hey, why not?